### PR TITLE
Implement tag-driven weapon synergy framework

### DIFF
--- a/GameDesignPrototype_1/objects/obj_player/Create_0.gml
+++ b/GameDesignPrototype_1/objects/obj_player/Create_0.gml
@@ -29,6 +29,10 @@ timers = new TimerComponent();
 // ==========================================
 class_component = CreateCharacterClass(character_class, stats, damage_sys, class_stats);
 
+// Synergy tagging
+synergy_tags = GetClassSynergyTags(character_class);
+active_synergy_sources = [];
+
 // Legacy compatibility (remove once fully refactored)
 attack		 = stats.attack;
 base_attack	 = stats.base_attack;
@@ -63,12 +67,17 @@ weapons = array_create(weapon_slots, noone);
 current_weapon_index = 0;
 
 // Give starting weapon
-//weapons[1] = global.WeaponStruct.Dagger; // Or whatever starting weapon
-weapons[1] = undefined;
-weapons[0] = global.WeaponStruct.Dagger; // Or whatever starting weapon
-weaponCurrent = weapons[0];
+var _starting_weapon = EnsureWeaponInstance(global.WeaponStruct.Dagger);
+weapons[0] = _starting_weapon;
+weaponCurrent = _starting_weapon;
+
+if (weapon_slots > 1) {
+    weapons[1] = undefined;
+}
 
 previous_weapon_instance = weaponCurrent;
+
+RefreshPlayerWeaponSynergies(self, weaponCurrent);
 
 
 // Charge weapon
@@ -159,9 +168,6 @@ carried_object = noone;
 carry_speed_multiplier = 0.8; // Slower when carrying
 
 
-var test_synergy = GetWeaponSynergy(CharacterClass.HOLY_MAGE, Weapon.BaseballBat);
-show_debug_message("Test synergy type: " + string(test_synergy.type));
-show_debug_message("Damage mult: " + string(test_synergy.damage_mult));
 
 
 

--- a/GameDesignPrototype_1/objects/obj_player/Step_0.gml
+++ b/GameDesignPrototype_1/objects/obj_player/Step_0.gml
@@ -224,13 +224,15 @@ function AttemptPickup() {
             
             // **SWITCH TO THROWABLE WEAPON**
             previous_weapon_instance = weaponCurrent; // Store current weapon
-            weaponCurrent = global.WeaponStruct.ThrowableItem;
+            weaponCurrent = EnsureWeaponInstance(global.WeaponStruct.ThrowableItem);
             charge_amount = 0;
             
             if (variable_instance_exists(nearest, "OnPickedUp")) {
                 nearest.OnPickedUp(id);
             }
             
+            RefreshPlayerWeaponSynergies(id, weaponCurrent);
+
             show_debug_message("Picked up: " + object_get_name(nearest.object_index));
         }
     }
@@ -268,6 +270,9 @@ function ThrowCarriedObject() {
     carried_object = noone;
     stats.temp_speed_mult = 1.0; // Restore speed
     weaponCurrent = previous_weapon_instance;
+    if (weaponCurrent != undefined) {
+        RefreshPlayerWeaponSynergies(id, weaponCurrent);
+    }
     show_debug_message("Threw object!");
 }
 
@@ -293,6 +298,9 @@ function DropCarriedObject() {
         obj.OnDropped(id);
     }
     weaponCurrent = previous_weapon_instance;
+    if (weaponCurrent != undefined) {
+        RefreshPlayerWeaponSynergies(id, weaponCurrent);
+    }
     carried_object = noone;
     stats.temp_speed_mult = 1.0;
 }
@@ -462,12 +470,16 @@ function HandleWeaponSwitching() {
         }
     }
 	
-	if (keyboard_check_pressed(ord("7"))) {
+        if (keyboard_check_pressed(ord("7"))) {
     if (instance_exists(melee_weapon)) instance_destroy(melee_weapon);
-    new_weapon = global.WeaponStruct.ChainWhip;
+    new_weapon = EnsureWeaponInstance(global.WeaponStruct.ChainWhip);
+    weaponCurrent = new_weapon;
+    weapons[current_weapon_index] = new_weapon;
     melee_weapon = instance_create_depth(x, y, depth-1, obj_chain_whip);
     melee_weapon.owner = id;
+    melee_weapon.weapon_id = weaponCurrent.id;
     weapon_changed = true;
+    RefreshPlayerWeaponSynergies(id, weaponCurrent);
 }
 }
 

--- a/GameDesignPrototype_1/objects/obj_weapon_pickup/Step_0.gml
+++ b/GameDesignPrototype_1/objects/obj_weapon_pickup/Step_0.gml
@@ -18,6 +18,9 @@ if (dist <= pickup_range && can_pickup) {
     // Press E to pickup
     if (keyboard_check_pressed(ord("E"))) {
         if (weapon_data != undefined) {
+            weapon_data = EnsureWeaponInstance(weapon_data);
+            self.weapon_data = weapon_data;
+
             var slot = player.current_weapon_index;
             var old_weapon = player.weapons[slot];
             
@@ -39,7 +42,8 @@ if (dist <= pickup_range && can_pickup) {
             
             // Update current weapon reference
             player.weaponCurrent = weapon_data;
-            
+            player.previous_weapon_instance = weapon_data;
+
             // Handle melee weapon switching
             if (weapon_data.type == WeaponType.Melee) {
                 if (instance_exists(player.melee_weapon)) {
@@ -58,6 +62,8 @@ if (dist <= pickup_range && can_pickup) {
                     player.melee_weapon = noone;
                 }
             }
+
+            RefreshPlayerWeaponSynergies(player, weapon_data);
             
             // Visual feedback
             var popup = instance_create_depth(x, y - 40, -9999, obj_floating_text);

--- a/GameDesignPrototype_1/rooms/rm_demo_room/InstanceCreationCode_inst_41C284FB.gml
+++ b/GameDesignPrototype_1/rooms/rm_demo_room/InstanceCreationCode_inst_41C284FB.gml
@@ -1,3 +1,3 @@
-weapon_data = global.WeaponStruct.Sword;
+weapon_data = EnsureWeaponInstance(global.WeaponStruct.Sword);
 weapon_name = "Sword";
 weapon_sprite = spr_sword;

--- a/GameDesignPrototype_1/rooms/rm_demo_room/InstanceCreationCode_inst_6932667A.gml
+++ b/GameDesignPrototype_1/rooms/rm_demo_room/InstanceCreationCode_inst_6932667A.gml
@@ -1,4 +1,4 @@
 // For Holy Water pickup
-weapon_data = global.WeaponStruct.HolyWater;
+weapon_data = EnsureWeaponInstance(global.WeaponStruct.HolyWater);
 weapon_name = "Holy Water";
 weapon_sprite = spr_holy_water;

--- a/GameDesignPrototype_1/scripts/ENUMS/ENUMS.gml
+++ b/GameDesignPrototype_1/scripts/ENUMS/ENUMS.gml
@@ -140,7 +140,8 @@ enum SynergyType {
     // Vampire synergies
     BLOOD_BAT,              // Vampire + Bat: Lifesteal on hit
     CRIMSON_BLADE,          // Vampire + Sword: Blood trail projectiles
-    
+    LIFESTEAL_GRENADE,      // Vampire + Grenade: Lifesteal explosion
+
     // Can add more as needed
 }
 
@@ -152,6 +153,11 @@ enum SynergyProjectileBehavior {
     ON_COMBO_FINISH,        // Spawn on final combo hit only
     REPLACE_ATTACK,         // Don't swing, just shoot projectile
     THROW_STYLE             // Change grenade throw behavior
+}
+
+enum SynergyTagMatch {
+    ALL,
+    ANY
 }
 
 

--- a/GameDesignPrototype_1/scripts/Weapons_STRUCT/Weapons_STRUCT.gml
+++ b/GameDesignPrototype_1/scripts/Weapons_STRUCT/Weapons_STRUCT.gml
@@ -543,7 +543,7 @@ global.WeaponStruct =
         if (instance_exists(_self.previous_weapon_instance)) {
             _self.weaponCurrent = _self.previous_weapon_instance;
         } else {
-            _self.weaponCurrent = global.WeaponStruct.Bow; // Default fallback
+            _self.weaponCurrent = EnsureWeaponInstance(global.WeaponStruct.Bow); // Default fallback
         }
         
         return obj;
@@ -600,7 +600,7 @@ global.WeaponStruct =
     if (instance_exists(_self.previous_weapon_instance)) {
         _self.weaponCurrent = _self.previous_weapon_instance;
     } else {
-        _self.weaponCurrent = global.WeaponStruct.Bow;
+        _self.weaponCurrent = EnsureWeaponInstance(global.WeaponStruct.Bow);
     }
     
     return obj;

--- a/GameDesignPrototype_1/scripts/scr_WeaponPickup/scr_WeaponPickup.gml
+++ b/GameDesignPrototype_1/scripts/scr_WeaponPickup/scr_WeaponPickup.gml
@@ -2,7 +2,7 @@
 function SpawnWeaponPickup(_x, _y, _weapon_struct) {
     var pickup = instance_create_depth(_x, _y, 0, obj_weapon_pickup);
     
-    pickup.weapon_data = _weapon_struct;
+    pickup.weapon_data = EnsureWeaponInstance(_weapon_struct);
     pickup.weapon_name = _weapon_struct.name;
     
     // Set sprite based on weapon

--- a/GameDesignPrototype_1/scripts/scr_WeaponsManager/scr_WeaponsManager.gml
+++ b/GameDesignPrototype_1/scripts/scr_WeaponsManager/scr_WeaponsManager.gml
@@ -42,9 +42,11 @@ function GiveWeapon(_player, _weapon_id) {
 /// @function EquipWeaponToSlot(_player, _weapon_struct, _slot_index)
 /// @description Equip a weapon to a specific slot
 function EquipWeaponToSlot(_player, _weapon_struct, _slot_index) {
+    _weapon_struct = EnsureWeaponInstance(_weapon_struct);
+
     // Store weapon in slot
     _player.weapons[_slot_index] = _weapon_struct;
-    
+
     // If equipping to current slot, update active weapon
     if (_slot_index == _player.current_weapon_index) {
         _player.weaponCurrent = _weapon_struct;
@@ -66,29 +68,47 @@ function EquipWeaponToSlot(_player, _weapon_struct, _slot_index) {
                 _player.melee_weapon.weapon_id = _weapon_struct.id;
             }
         }
+
+        RefreshPlayerWeaponSynergies(_player, _weapon_struct);
     }
 }
 
 /// @function GetWeaponStructById(_weapon_id)
 /// @description Get weapon struct from global.WeaponStruct by ID
 function GetWeaponStructById(_weapon_id) {
+    var base_struct;
     switch (_weapon_id) {
-        case Weapon.Sword: return global.WeaponStruct.Sword;
-        case Weapon.Bow: return global.WeaponStruct.Bow;
-        case Weapon.Dagger: return global.WeaponStruct.Dagger;
-        case Weapon.Boomerang: return global.WeaponStruct.Boomerang;
-        case Weapon.ChargeCannon: return global.WeaponStruct.ChargeCannon;
-        case Weapon.BaseballBat: return global.WeaponStruct.BaseballBat;
-        case Weapon.Holy_Water: return global.WeaponStruct.HolyWater;
-        default: return undefined;
+        case Weapon.Sword: base_struct = global.WeaponStruct.Sword; break;
+        case Weapon.Bow: base_struct = global.WeaponStruct.Bow; break;
+        case Weapon.Dagger: base_struct = global.WeaponStruct.Dagger; break;
+        case Weapon.Boomerang: base_struct = global.WeaponStruct.Boomerang; break;
+        case Weapon.ChargeCannon: base_struct = global.WeaponStruct.ChargeCannon; break;
+        case Weapon.BaseballBat: base_struct = global.WeaponStruct.BaseballBat; break;
+        case Weapon.Holy_Water: base_struct = global.WeaponStruct.HolyWater; break;
+        case Weapon.ChainWhip: base_struct = global.WeaponStruct.ChainWhip; break;
+        case Weapon.ThrowableItem: base_struct = global.WeaponStruct.ThrowableItem; break;
+        default: base_struct = undefined; break;
     }
+
+    if (base_struct == undefined) return undefined;
+    return EnsureWeaponInstance(base_struct);
 }
 
 /// @function GetWeaponName(_weapon_id)
 /// @description Get display name for weapon
 function GetWeaponName(_weapon_id) {
-    var weapon_struct = GetWeaponStructById(_weapon_id);
-    return weapon_struct != undefined ? weapon_struct.name : "Unknown Weapon";
+    switch (_weapon_id) {
+        case Weapon.Sword: return global.WeaponStruct.Sword.name;
+        case Weapon.Bow: return global.WeaponStruct.Bow.name;
+        case Weapon.Dagger: return global.WeaponStruct.Dagger.name;
+        case Weapon.Boomerang: return global.WeaponStruct.Boomerang.name;
+        case Weapon.ChargeCannon: return global.WeaponStruct.ChargeCannon.name;
+        case Weapon.BaseballBat: return global.WeaponStruct.BaseballBat.name;
+        case Weapon.Holy_Water: return global.WeaponStruct.HolyWater.name;
+        case Weapon.ChainWhip: return global.WeaponStruct.ChainWhip.name;
+        case Weapon.ThrowableItem: return global.WeaponStruct.ThrowableItem.name;
+        default: return "Unknown Weapon";
+    }
 }
 
 // ==========================================
@@ -264,7 +284,8 @@ function SwitchToWeaponSlot(_slot_index) {
     if (weapons[_slot_index] == noone) return;
     
     current_weapon_index = _slot_index;
-    weaponCurrent = weapons[_slot_index];
+    weaponCurrent = EnsureWeaponInstance(weapons[_slot_index]);
+    weapons[_slot_index] = weaponCurrent;
     if !(weaponCurrent) return;
     // Handle melee weapon switching
     if (weaponCurrent.type == WeaponType.Melee) {
@@ -284,6 +305,8 @@ function SwitchToWeaponSlot(_slot_index) {
             melee_weapon = noone;
         }
     }
-    
+
+    RefreshPlayerWeaponSynergies(id, weaponCurrent);
+
     show_debug_message("Switched to " + weaponCurrent.name);
 }

--- a/GameDesignPrototype_1/scripts/scr_weapon_synergies/scr_weapon_synergies.gml
+++ b/GameDesignPrototype_1/scripts/scr_weapon_synergies/scr_weapon_synergies.gml
@@ -1,194 +1,736 @@
 // ==========================================
-// WEAPON SYNERGY SYSTEM
+// DYNAMIC WEAPON SYNERGY SYSTEM
 // ==========================================
 
-/// @desc Initialize synergy lookup table (call in game init)
+/// @desc Initialize the dynamic synergy system (call during game init)
 function InitWeaponSynergySystem() {
-    global.WeaponSynergies = {};
-    
-    // Define all synergies as [Character][Weapon] = SynergyData
-    // Format: "CHARACTER_WEAPON" = synergy config
-    
-    // ===== MAGE SYNERGIES =====
-    global.WeaponSynergies.MAGE_BAT = {
+    global.SynergyData = {};
+    global.SynergyRules = [];
+    global.SynergyClassTags = {};
+    global.SynergyWeaponTags = {};
+
+    // ------------------------------------------
+    // CLASS TAGS
+    // ------------------------------------------
+    global.SynergyClassTags[$ string(CharacterClass.WARRIOR)] = [
+        "PLAYER", "CLASS_WARRIOR", "MELEE", "BRUTE"
+    ];
+    global.SynergyClassTags[$ string(CharacterClass.HOLY_MAGE)] = [
+        "PLAYER", "CLASS_MAGE", "ARCANE", "HOLY"
+    ];
+    global.SynergyClassTags[$ string(CharacterClass.VAMPIRE)] = [
+        "PLAYER", "CLASS_VAMPIRE", "BLOOD", "UNDEAD"
+    ];
+
+    // Placeholder for future class additions
+    global.SynergyClassTags[$ "BASEBALL_CLASS"] = [
+        "PLAYER", "CLASS_BASEBALL", "MELEE", "ATHLETE"
+    ];
+
+    // ------------------------------------------
+    // WEAPON TAGS
+    // ------------------------------------------
+    global.SynergyWeaponTags[$ string(Weapon.Sword)] = [
+        "WEAPON", "MELEE", "SWORD", "BLADE"
+    ];
+    global.SynergyWeaponTags[$ string(Weapon.Dagger)] = [
+        "WEAPON", "MELEE", "DAGGER", "BLADE", "PIERCE"
+    ];
+    global.SynergyWeaponTags[$ string(Weapon.BaseballBat)] = [
+        "WEAPON", "MELEE", "BAT", "BLUNT"
+    ];
+    global.SynergyWeaponTags[$ string(Weapon.Holy_Water)] = [
+        "WEAPON", "GRENADE", "EXPLOSIVE", "HOLY"
+    ];
+    global.SynergyWeaponTags[$ string(Weapon.Bow)] = [
+        "WEAPON", "RANGED", "BOW", "PROJECTILE"
+    ];
+    global.SynergyWeaponTags[$ string(Weapon.Boomerang)] = [
+        "WEAPON", "RANGED", "BOOMERANG", "THROWN"
+    ];
+    global.SynergyWeaponTags[$ string(Weapon.ChargeCannon)] = [
+        "WEAPON", "RANGED", "CANNON", "EXPLOSIVE"
+    ];
+    global.SynergyWeaponTags[$ string(Weapon.ChainWhip)] = [
+        "WEAPON", "MELEE", "WHIP", "CHAIN"
+    ];
+    global.SynergyWeaponTags[$ string(Weapon.ThrowableItem)] = [
+        "WEAPON", "THROWABLE"
+    ];
+
+    // ------------------------------------------
+    // SYNERGY DATA DEFINITIONS
+    // ------------------------------------------
+    global.SynergyData.SPELL_BASEBALL = {
+        key: "SPELL_BASEBALL",
         type: SynergyType.SPELL_BASEBALL,
-        damage_mult: 0.7,           // Mage isn't strong, 70% damage
-        knockback_mult: 0.6,        // 60% knockback
+        damage_mult: 0.7,
+        knockback_mult: 0.6,
         attack_speed_mult: 1.0,
-        projectile: obj_magic_baseball,  // NEW OBJECT NEEDED
+        projectile: obj_magic_baseball,
         projectile_behavior: SynergyProjectileBehavior.ON_SWING,
-        projectile_count: 2,        // Spawns 2 magic baseballs per swing
-        projectile_spread: 30       // Degrees apart
+        projectile_count: 2,
+        projectile_spread: 30
     };
-    
-    global.WeaponSynergies.MAGE_SWORD = {
+
+    global.SynergyData.ARCANE_BLADE = {
+        key: "ARCANE_BLADE",
         type: SynergyType.ARCANE_BLADE,
         damage_mult: 0.8,
         knockback_mult: 0.7,
-        attack_speed_mult: 1.2,     // Faster swings
-        projectile: obj_arcane_slash, // NEW OBJECT NEEDED
+        attack_speed_mult: 1.2,
+        projectile: obj_arcane_slash,
         projectile_behavior: SynergyProjectileBehavior.ON_SWING,
         projectile_count: 1
     };
-    
-    global.WeaponSynergies.MAGE_GRENADE = {
+
+    global.SynergyData.HOLY_BOMB = {
+        key: "HOLY_BOMB",
         type: SynergyType.HOLY_GRENADE,
-        damage_mult: 1.5,           // Holy power boost
+        damage_mult: 1.5,
+        knockback_mult: 1.0,
+        attack_speed_mult: 1.0,
         explosion_radius_mult: 1.3,
-        projectile: obj_holy_water, // Existing object
+        projectile: obj_holy_water,
+        projectile_behavior: SynergyProjectileBehavior.THROW_STYLE,
         throw_style: "holy_arc"
     };
-    
-    // ===== BASEBALL PLAYER SYNERGIES =====
-    global.WeaponSynergies.BASEBALL_BAT = {
+
+    global.SynergyData.HOMERUN_MASTER = {
+        key: "HOMERUN_MASTER",
         type: SynergyType.HOMERUN_MASTER,
         damage_mult: 1.3,
-        knockback_mult: 2.5,        // HUGE knockback
-        attack_speed_mult: 0.9,     // Slightly slower windups
-        homerun_chance: 0.35,       // 35% chance (adds to base)
+        knockback_mult: 2.5,
+        attack_speed_mult: 0.9,
+        homerun_chance: 0.35,
         projectile_behavior: SynergyProjectileBehavior.NONE
     };
-    
-    global.WeaponSynergies.BASEBALL_GRENADE = {
+
+    global.SynergyData.FASTBALL_GRENADE = {
+        key: "FASTBALL_GRENADE",
         type: SynergyType.FASTBALL_THROW,
         damage_mult: 1.0,
-        throw_speed_mult: 2.0,      // Throws 2x faster
-        throw_style: "fastball",    // Straight line, no arc
-        projectile: obj_grenade     // Use regular grenade but modified behavior
+        knockback_mult: 1.0,
+        attack_speed_mult: 1.0,
+        throw_speed_mult: 2.0,
+        projectile_behavior: SynergyProjectileBehavior.THROW_STYLE,
+        throw_style: "fastball",
+        projectile: obj_grenade
     };
-    
-    // ===== WARRIOR SYNERGIES =====
-    global.WeaponSynergies.WARRIOR_BAT = {
+
+    global.SynergyData.BRUTAL_SWING = {
+        key: "BRUTAL_SWING",
         type: SynergyType.BRUTAL_SWING,
         damage_mult: 1.5,
         knockback_mult: 1.8,
-        attack_speed_mult: 0.7,     // Much slower
+        attack_speed_mult: 0.7,
         projectile_behavior: SynergyProjectileBehavior.NONE
     };
-    
-    global.WeaponSynergies.WARRIOR_SWORD = {
+
+    global.SynergyData.RAGE_BLADE = {
+        key: "RAGE_BLADE",
         type: SynergyType.RAGE_BLADE,
         damage_mult: 1.2,
         knockback_mult: 1.1,
-        rage_gain_on_hit: 0.15,     // Builds rage faster
+        attack_speed_mult: 1.0,
+        rage_gain_on_hit: 0.15,
         projectile_behavior: SynergyProjectileBehavior.NONE
     };
-    
-    // ===== VAMPIRE SYNERGIES =====
-    global.WeaponSynergies.VAMPIRE_BAT = {
+
+    global.SynergyData.BLOOD_BAT = {
+        key: "BLOOD_BAT",
         type: SynergyType.BLOOD_BAT,
         damage_mult: 1.0,
         knockback_mult: 1.0,
-        lifesteal_bonus: 0.10,      // +10% lifesteal on bat hits
+        attack_speed_mult: 1.0,
+        lifesteal_bonus: 0.10,
         projectile_behavior: SynergyProjectileBehavior.NONE
     };
-    
-    global.WeaponSynergies.VAMPIRE_SWORD = {
+
+    global.SynergyData.CRIMSON_BLADE = {
+        key: "CRIMSON_BLADE",
         type: SynergyType.CRIMSON_BLADE,
         damage_mult: 1.1,
         knockback_mult: 0.9,
-        projectile: obj_blood_projectile, // NEW OBJECT NEEDED
+        attack_speed_mult: 1.0,
+        projectile: obj_blood_projectile,
         projectile_behavior: SynergyProjectileBehavior.ON_HIT,
         projectile_count: 3,
         lifesteal_bonus: 0.05
     };
+
+    global.SynergyData.LIFESTEAL_BOMB = {
+        key: "LIFESTEAL_BOMB",
+        type: SynergyType.LIFESTEAL_GRENADE,
+        damage_mult: 1.2,
+        knockback_mult: 1.0,
+        attack_speed_mult: 1.0,
+        lifesteal_percent: 0.25,
+        projectile: obj_grenade,
+        projectile_behavior: SynergyProjectileBehavior.THROW_STYLE,
+        throw_style: "blood_arc"
+    };
+
+    // Maintain legacy alias for compatibility if other systems still reference global.WeaponSynergies
+    global.WeaponSynergies = global.SynergyData;
+
+    // ------------------------------------------
+    // SYNERGY RULES (TAG BASED)
+    // ------------------------------------------
+    global.SynergyRules = [
+        {
+            synergy_key: "SPELL_BASEBALL",
+            groups: [
+                { tags: ["CLASS_MAGE"], sources: ["player"] },
+                { tags: ["BAT"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "ARCANE_BLADE",
+            groups: [
+                { tags: ["CLASS_MAGE"], sources: ["player"] },
+                { tags: ["SWORD"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "HOLY_BOMB",
+            groups: [
+                { tags: ["CLASS_MAGE"], sources: ["player"] },
+                { tags: ["EXPLOSIVE"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "HOMERUN_MASTER",
+            groups: [
+                { tags: ["CLASS_BASEBALL"], sources: ["player"] },
+                { tags: ["BAT"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "FASTBALL_GRENADE",
+            groups: [
+                { tags: ["CLASS_BASEBALL"], sources: ["player"] },
+                { tags: ["GRENADE"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "BRUTAL_SWING",
+            groups: [
+                { tags: ["CLASS_WARRIOR"], sources: ["player"] },
+                { tags: ["BAT"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "RAGE_BLADE",
+            groups: [
+                { tags: ["CLASS_WARRIOR"], sources: ["player"] },
+                { tags: ["SWORD"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "BLOOD_BAT",
+            groups: [
+                { tags: ["CLASS_VAMPIRE"], sources: ["player"] },
+                { tags: ["BAT"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "CRIMSON_BLADE",
+            groups: [
+                { tags: ["CLASS_VAMPIRE"], sources: ["player"] },
+                { tags: ["SWORD"], sources: ["weapon"] }
+            ]
+        },
+        {
+            synergy_key: "LIFESTEAL_BOMB",
+            groups: [
+                { tags: ["CLASS_VAMPIRE"], sources: ["player"] },
+                { tags: ["EXPLOSIVE"], sources: ["weapon"] }
+            ]
+        }
+    ];
 }
 
-/// @desc Get weapon category from weapon enum
-function GetWeaponCategory(_weapon_id) {
-    switch (_weapon_id) {
-        case Weapon.Sword: return WeaponCategory.SWORD;
-        case Weapon.BaseballBat: return WeaponCategory.BAT;
-        case Weapon.Dagger: return WeaponCategory.DAGGER;
-        case Weapon.Holy_Water: return WeaponCategory.GRENADE;
-        case Weapon.Bow: return WeaponCategory.BOW;
-        case Weapon.ChargeCannon: return WeaponCategory.CANNON;
-        case Weapon.Boomerang: return WeaponCategory.BOOMERANG;
-        default: return WeaponCategory.SWORD;
+// ------------------------------------------
+// TAG UTILITIES
+// ------------------------------------------
+function GetClassSynergyTags(_class) {
+    var key = string(_class);
+    if (variable_struct_exists(global.SynergyClassTags, key)) {
+        return SynergyDeepCopyArray(global.SynergyClassTags[$ key]);
+    }
+    return [];
+}
+
+function GetWeaponSynergyTags(_weapon_id) {
+    var key = string(_weapon_id);
+    if (variable_struct_exists(global.SynergyWeaponTags, key)) {
+        return SynergyDeepCopyArray(global.SynergyWeaponTags[$ key]);
+    }
+    return [];
+}
+
+function SynergyEnsureArray(_value) {
+    if (_value == undefined) return [];
+    if (is_array(_value)) return _value;
+    return [_value];
+}
+
+function SynergyArrayContains(_array, _value) {
+    if (!is_array(_array)) return false;
+    for (var i = 0; i < array_length(_array); i++) {
+        if (_array[i] == _value) return true;
+    }
+    return false;
+}
+
+function SynergyArrayPushUnique(_array, _value) {
+    if (!SynergyArrayContains(_array, _value)) {
+        array_push(_array, _value);
+    }
+    return _array;
+}
+
+function SynergyStringEndsWith(_value, _suffix) {
+    if (!is_string(_value) || !is_string(_suffix)) return false;
+    var suffix_len = string_length(_suffix);
+    if (suffix_len == 0) return true;
+    if (string_length(_value) < suffix_len) return false;
+    return string_copy(_value, string_length(_value) - suffix_len + 1, suffix_len) == _suffix;
+}
+
+function SynergyDeepCopyArray(_array) {
+    if (!is_array(_array)) return [];
+    var len = array_length(_array);
+    var result = array_create(len);
+    for (var i = 0; i < len; i++) {
+        var value = _array[i];
+        if (is_array(value)) {
+            result[i] = SynergyDeepCopyArray(value);
+        } else if (is_struct(value)) {
+            result[i] = SynergyDeepCopyStruct(value);
+        } else {
+            result[i] = value;
+        }
+    }
+    return result;
+}
+
+function SynergyDeepCopyStruct(_struct) {
+    if (!is_struct(_struct)) return {};
+    var names = struct_get_names(_struct);
+    var copy = {};
+    for (var i = 0; i < array_length(names); i++) {
+        var name = names[i];
+        var value = _struct[$ name];
+        if (is_array(value)) {
+            copy[$ name] = SynergyDeepCopyArray(value);
+        } else if (is_struct(value)) {
+            copy[$ name] = SynergyDeepCopyStruct(value);
+        } else {
+            copy[$ name] = value;
+        }
+    }
+    return copy;
+}
+
+function EnsureWeaponInstance(_weapon_struct) {
+    if (_weapon_struct == undefined) return undefined;
+
+    if (is_struct(_weapon_struct) && variable_struct_exists(_weapon_struct, "__is_instance") && _weapon_struct.__is_instance) {
+        return _weapon_struct;
+    }
+
+    var clone = SynergyDeepCopyStruct(_weapon_struct);
+    clone.__is_instance = true;
+
+    if (!variable_struct_exists(clone, "synergy_tags") || !is_array(clone.synergy_tags)) {
+        clone.synergy_tags = GetWeaponSynergyTags(clone.id);
+    }
+
+    return clone;
+}
+
+function SynergyGetTagsFromSource(_source) {
+    if (_source == undefined) return [];
+
+    if (is_struct(_source)) {
+        if (variable_struct_exists(_source, "synergy_tags") && is_array(_source.synergy_tags)) {
+            return SynergyDeepCopyArray(_source.synergy_tags);
+        }
+        if (variable_struct_exists(_source, "tags") && is_array(_source.tags)) {
+            return SynergyDeepCopyArray(_source.tags);
+        }
+    } else {
+        if (variable_instance_exists(_source, "synergy_tags") && is_array(_source.synergy_tags)) {
+            return SynergyDeepCopyArray(_source.synergy_tags);
+        }
+        if (variable_instance_exists(_source, "tags") && is_array(_source.tags)) {
+            return SynergyDeepCopyArray(_source.tags);
+        }
+    }
+
+    return [];
+}
+
+function SynergyTagsMatch(_source_tags, _required_tags, _mode) {
+    if (!is_array(_required_tags) || array_length(_required_tags) == 0) return true;
+    if (!is_array(_source_tags) || array_length(_source_tags) == 0) return false;
+
+    var mode = (_mode == undefined) ? SynergyTagMatch.ALL : _mode;
+
+    switch (mode) {
+        case SynergyTagMatch.ANY:
+            for (var i = 0; i < array_length(_required_tags); i++) {
+                if (SynergyArrayContains(_source_tags, _required_tags[i])) return true;
+            }
+            return false;
+
+        default: // SynergyTagMatch.ALL
+            for (var j = 0; j < array_length(_required_tags); j++) {
+                if (!SynergyArrayContains(_source_tags, _required_tags[j])) return false;
+            }
+            return true;
     }
 }
 
-/// @desc Get character archetype from character class
-function GetCharacterArchetype(_character_class) {
-    switch (_character_class) {
-        case CharacterClass.WARRIOR: return CharacterArchetype.WARRIOR;
-        case CharacterClass.HOLY_MAGE: return CharacterArchetype.MAGE;
-        case CharacterClass.VAMPIRE: return CharacterArchetype.VAMPIRE;
-        default: return CharacterArchetype.WARRIOR;
+function SynergyGroupMatches(_group, _sources) {
+    if (!is_struct(_group)) return false;
+    var tags_required = SynergyEnsureArray(_group.tags);
+
+    if (array_length(tags_required) == 0) return true;
+
+    var allowed_sources = SynergyEnsureArray(_group.sources);
+    var mode = (variable_struct_exists(_group, "mode")) ? _group.mode : SynergyTagMatch.ALL;
+
+    for (var i = 0; i < array_length(_sources); i++) {
+        var src = _sources[i];
+        var src_tags = src.tags;
+        var src_label = src.label;
+
+        if (array_length(allowed_sources) > 0 && !SynergyArrayContains(allowed_sources, src_label)) {
+            continue;
+        }
+
+        if (SynergyTagsMatch(src_tags, tags_required, mode)) {
+            return true;
+        }
     }
+
+    return false;
 }
 
-/// @desc Main function: Get synergy data for character + weapon combo
-function GetWeaponSynergy(_character_class, _weapon_id) {
-    var archetype = GetCharacterArchetype(_character_class);
-    var category = GetWeaponCategory(_weapon_id);
-    
-    // Build lookup key
-    var archetype_name = GetArchetypeName(archetype);
-    var category_name = GetCategoryName(category);
-    var key = archetype_name + "_" + category_name;
-    
-    // Check if synergy exists
-    if (variable_struct_exists(global.WeaponSynergies, key)) {
-        return global.WeaponSynergies[$ key];
+function SynergyRuleMatches(_rule, _sources) {
+    if (!is_struct(_rule)) return false;
+    var groups = _rule.groups;
+    if (!is_array(groups) || array_length(groups) == 0) return false;
+
+    for (var i = 0; i < array_length(groups); i++) {
+        if (!SynergyGroupMatches(groups[i], _sources)) {
+            return false;
+        }
     }
-    
-    // No synergy - return default
-    return {
+    return true;
+}
+
+function EvaluateDynamicSynergies(_player, _weapon_struct, _extra_sources) {
+    if (_weapon_struct == undefined) return [];
+
+    var sources = [];
+    array_push(sources, { label: "player", tags: SynergyGetTagsFromSource(_player) });
+    array_push(sources, { label: "weapon", tags: SynergyGetTagsFromSource(_weapon_struct) });
+
+    if (_extra_sources != undefined) {
+        if (is_array(_extra_sources)) {
+            for (var i = 0; i < array_length(_extra_sources); i++) {
+                var entry = _extra_sources[i];
+                if (entry == undefined) continue;
+
+                var label = "extra_" + string(i);
+                var tags = [];
+
+                if (is_struct(entry)) {
+                    if (variable_struct_exists(entry, "label")) {
+                        label = entry.label;
+                    }
+                    tags = SynergyGetTagsFromSource(entry);
+                } else if (is_array(entry)) {
+                    tags = SynergyDeepCopyArray(entry);
+                }
+
+                if (array_length(tags) > 0) {
+                    array_push(sources, { label: label, tags: tags });
+                }
+            }
+        } else if (is_struct(_extra_sources)) {
+            var label_single = variable_struct_exists(_extra_sources, "label") ? _extra_sources.label : "extra";
+            var tags_single = SynergyGetTagsFromSource(_extra_sources);
+            if (array_length(tags_single) > 0) {
+                array_push(sources, { label: label_single, tags: tags_single });
+            }
+        }
+    }
+
+    var results = [];
+    if (!is_array(global.SynergyRules)) return results;
+
+    for (var r = 0; r < array_length(global.SynergyRules); r++) {
+        var rule = global.SynergyRules[r];
+        if (!is_struct(rule)) continue;
+
+        if (SynergyRuleMatches(rule, sources)) {
+            var key = rule.synergy_key;
+            if (key != undefined && variable_struct_exists(global.SynergyData, key)) {
+                array_push(results, global.SynergyData[$ key]);
+            }
+        }
+    }
+
+    return results;
+}
+
+function CombineSynergyData(_synergy_list) {
+    var combined = {
+        key: "NONE",
+        keys: [],
         type: SynergyType.NONE,
         damage_mult: 1.0,
         knockback_mult: 1.0,
         attack_speed_mult: 1.0,
-        projectile_behavior: SynergyProjectileBehavior.NONE
+        projectile_behavior: SynergyProjectileBehavior.NONE,
+        projectile: noone,
+        projectile_count: 0,
+        projectile_spread: 0
     };
-}
 
-/// @desc Helper to get archetype name as string
-function GetArchetypeName(_archetype) {
-    switch (_archetype) {
-        case CharacterArchetype.WARRIOR: return "WARRIOR";
-        case CharacterArchetype.MAGE: return "MAGE";
-        case CharacterArchetype.BASEBALL_PLAYER: return "BASEBALL";
-        case CharacterArchetype.VAMPIRE: return "VAMPIRE";
-        case CharacterArchetype.ROGUE: return "ROGUE";
-        default: return "WARRIOR";
-    }
-}
+    if (!is_array(_synergy_list)) return combined;
 
-/// @desc Helper to get category name as string
-function GetCategoryName(_category) {
-    switch (_category) {
-        case WeaponCategory.SWORD: return "SWORD";
-        case WeaponCategory.BAT: return "BAT";
-        case WeaponCategory.DAGGER: return "DAGGER";
-        case WeaponCategory.GRENADE: return "GRENADE";
-        case WeaponCategory.BOW: return "BOW";
-        case WeaponCategory.CANNON: return "CANNON";
-        case WeaponCategory.BOOMERANG: return "BOOMERANG";
-        default: return "SWORD";
-    }
-}
+    for (var i = 0; i < array_length(_synergy_list); i++) {
+        var synergy = _synergy_list[i];
+        if (!is_struct(synergy)) continue;
 
-/// @desc Apply synergy modifications to weapon struct
-function ApplySynergyToWeapon(_weapon_struct, _synergy_data, _player) {
-    // Store synergy data in weapon
-    _weapon_struct.active_synergy = _synergy_data;
-    
-    // Modify combo attacks if weapon has them
-    if (variable_struct_exists(_weapon_struct, "combo_attacks")) {
-        for (var i = 0; i < array_length(_weapon_struct.combo_attacks); i++) {
-            _weapon_struct.combo_attacks[i].damage_mult *= _synergy_data.damage_mult;
-            _weapon_struct.combo_attacks[i].knockback_mult *= _synergy_data.knockback_mult;
-            _weapon_struct.combo_attacks[i].duration /= _synergy_data.attack_speed_mult;
+        var key = variable_struct_exists(synergy, "key") ? synergy.key : "";
+        if (key != "") {
+            array_push(combined.keys, key);
+            combined.key = key;
+        }
+
+        if (variable_struct_exists(synergy, "type") && synergy.type != SynergyType.NONE) {
+            combined.type = synergy.type;
+        }
+
+        combined.damage_mult *= (variable_struct_exists(synergy, "damage_mult")) ? synergy.damage_mult : 1.0;
+        combined.knockback_mult *= (variable_struct_exists(synergy, "knockback_mult")) ? synergy.knockback_mult : 1.0;
+        combined.attack_speed_mult *= (variable_struct_exists(synergy, "attack_speed_mult")) ? synergy.attack_speed_mult : 1.0;
+
+        if (variable_struct_exists(synergy, "projectile_behavior") && synergy.projectile_behavior != SynergyProjectileBehavior.NONE) {
+            combined.projectile_behavior = synergy.projectile_behavior;
+            combined.projectile = variable_struct_exists(synergy, "projectile") ? synergy.projectile : combined.projectile;
+            combined.projectile_count = variable_struct_exists(synergy, "projectile_count") ? synergy.projectile_count : max(1, combined.projectile_count);
+            combined.projectile_spread = variable_struct_exists(synergy, "projectile_spread") ? synergy.projectile_spread : combined.projectile_spread;
+        }
+
+        var names = struct_get_names(synergy);
+        for (var n = 0; n < array_length(names); n++) {
+            var name = names[n];
+            if (name == "key" || name == "type" || name == "damage_mult" || name == "knockback_mult" ||
+                name == "attack_speed_mult" || name == "projectile_behavior" || name == "projectile" ||
+                name == "projectile_count" || name == "projectile_spread") {
+                continue;
+            }
+
+            var value = synergy[$ name];
+            if (is_real(value)) {
+                if (SynergyStringEndsWith(name, "_mult")) {
+                    combined[$ name] = (variable_struct_exists(combined, name) ? combined[$ name] : 1.0) * value;
+                } else if (SynergyStringEndsWith(name, "_bonus") || SynergyStringEndsWith(name, "_chance") || SynergyStringEndsWith(name, "_percent")) {
+                    combined[$ name] = (variable_struct_exists(combined, name) ? combined[$ name] : 0) + value;
+                } else {
+                    combined[$ name] = value;
+                }
+            } else {
+                combined[$ name] = value;
+            }
         }
     }
-    
-    // Store projectile spawning behavior
-    if (_synergy_data.projectile_behavior != SynergyProjectileBehavior.NONE) {
-        _weapon_struct.spawn_projectiles = true;
-        _weapon_struct.projectile_type = _synergy_data.projectile;
-        _weapon_struct.projectile_behavior = _synergy_data.projectile_behavior;
-        _weapon_struct.projectile_count = _synergy_data.projectile_count ?? 1;
-        _weapon_struct.projectile_spread = _synergy_data.projectile_spread ?? 0;
+
+    if (combined.projectile_count <= 0 && combined.projectile_behavior != SynergyProjectileBehavior.NONE) {
+        combined.projectile_count = 1;
     }
+
+    return combined;
+}
+
+function ResetWeaponSynergyState(_weapon_struct) {
+    if (!is_struct(_weapon_struct)) return;
+
+    if (!variable_struct_exists(_weapon_struct, "__synergy_base")) {
+        var base_combo = [];
+        if (variable_struct_exists(_weapon_struct, "combo_attacks") && is_array(_weapon_struct.combo_attacks)) {
+            for (var i = 0; i < array_length(_weapon_struct.combo_attacks); i++) {
+                var attack = _weapon_struct.combo_attacks[i];
+                if (is_struct(attack)) {
+                    array_push(base_combo, {
+                        damage_mult: attack.damage_mult,
+                        knockback_mult: attack.knockback_mult,
+                        duration: attack.duration
+                    });
+                }
+            }
+        }
+
+        _weapon_struct.__synergy_base = {
+            combo_attacks: base_combo,
+            spawn_projectiles: variable_struct_exists(_weapon_struct, "spawn_projectiles") ? _weapon_struct.spawn_projectiles : false,
+            projectile_type: variable_struct_exists(_weapon_struct, "projectile_type") ? _weapon_struct.projectile_type : noone,
+            projectile_behavior: variable_struct_exists(_weapon_struct, "projectile_behavior") ? _weapon_struct.projectile_behavior : SynergyProjectileBehavior.NONE,
+            projectile_count: variable_struct_exists(_weapon_struct, "projectile_count") ? _weapon_struct.projectile_count : 0,
+            projectile_spread: variable_struct_exists(_weapon_struct, "projectile_spread") ? _weapon_struct.projectile_spread : 0,
+            field_defaults: {}
+        };
+    }
+
+    var base = _weapon_struct.__synergy_base;
+
+    if (variable_struct_exists(_weapon_struct, "combo_attacks") && is_array(base.combo_attacks)) {
+        for (var j = 0; j < array_length(base.combo_attacks); j++) {
+            if (j >= array_length(_weapon_struct.combo_attacks)) continue;
+            var original = base.combo_attacks[j];
+            if (!is_struct(original)) continue;
+            _weapon_struct.combo_attacks[j].damage_mult = original.damage_mult;
+            _weapon_struct.combo_attacks[j].knockback_mult = original.knockback_mult;
+            _weapon_struct.combo_attacks[j].duration = original.duration;
+        }
+    }
+
+    _weapon_struct.spawn_projectiles = base.spawn_projectiles;
+    _weapon_struct.projectile_type = base.projectile_type;
+    _weapon_struct.projectile_behavior = base.projectile_behavior;
+    _weapon_struct.projectile_count = base.projectile_count;
+    _weapon_struct.projectile_spread = base.projectile_spread;
+
+    if (variable_struct_exists(_weapon_struct, "__synergy_fields_applied")) {
+        var applied = _weapon_struct.__synergy_fields_applied;
+        if (is_array(applied)) {
+            for (var i = 0; i < array_length(applied); i++) {
+                var field = applied[i];
+                if (variable_struct_exists(base.field_defaults, field)) {
+                    var value = base.field_defaults[$ field];
+                    if (value == undefined) {
+                        if (variable_struct_exists(_weapon_struct, field)) {
+                            struct_delete(_weapon_struct, field);
+                        }
+                    } else {
+                        _weapon_struct[$ field] = value;
+                    }
+                } else if (variable_struct_exists(_weapon_struct, field)) {
+                    struct_delete(_weapon_struct, field);
+                }
+            }
+        }
+    }
+
+    _weapon_struct.__synergy_fields_applied = [];
+    _weapon_struct.active_synergy = undefined;
+    _weapon_struct.active_synergies = [];
+}
+
+function SynergySetWeaponField(_weapon_struct, _field, _value) {
+    if (!is_struct(_weapon_struct)) return;
+    var base = _weapon_struct.__synergy_base;
+    if (!is_struct(base)) return;
+
+    if (!variable_struct_exists(base, "field_defaults")) {
+        base.field_defaults = {};
+    }
+
+    if (!variable_struct_exists(base.field_defaults, _field)) {
+        if (variable_struct_exists(_weapon_struct, _field)) {
+            base.field_defaults[$ _field] = _weapon_struct[$ _field];
+        } else {
+            base.field_defaults[$ _field] = undefined;
+        }
+    }
+
+    _weapon_struct[$ _field] = _value;
+
+    if (!variable_struct_exists(_weapon_struct, "__synergy_fields_applied")) {
+        _weapon_struct.__synergy_fields_applied = [];
+    }
+
+    if (!SynergyArrayContains(_weapon_struct.__synergy_fields_applied, _field)) {
+        array_push(_weapon_struct.__synergy_fields_applied, _field);
+    }
+}
+
+function ApplySynergiesToWeapon(_weapon_struct, _synergy_list, _player) {
+    if (!is_struct(_weapon_struct)) return;
+
+    ResetWeaponSynergyState(_weapon_struct);
+
+    if (!is_array(_synergy_list) || array_length(_synergy_list) == 0) {
+        if (instance_exists(_player) && instance_exists(_player.melee_weapon)) {
+            _player.melee_weapon.synergy_data = undefined;
+        }
+        return;
+    }
+
+    var combined = CombineSynergyData(_synergy_list);
+
+    if (variable_struct_exists(_weapon_struct, "combo_attacks") && is_array(_weapon_struct.combo_attacks)) {
+        var base_combo = _weapon_struct.__synergy_base.combo_attacks;
+        for (var i = 0; i < array_length(base_combo); i++) {
+            if (i >= array_length(_weapon_struct.combo_attacks)) continue;
+            var original = base_combo[i];
+            if (!is_struct(original)) continue;
+
+            _weapon_struct.combo_attacks[i].damage_mult = original.damage_mult * combined.damage_mult;
+            _weapon_struct.combo_attacks[i].knockback_mult = original.knockback_mult * combined.knockback_mult;
+            _weapon_struct.combo_attacks[i].duration = max(1, original.duration / combined.attack_speed_mult);
+        }
+    }
+
+    if (combined.projectile_behavior != SynergyProjectileBehavior.NONE) {
+        SynergySetWeaponField(_weapon_struct, "spawn_projectiles", true);
+        SynergySetWeaponField(_weapon_struct, "projectile_type", combined.projectile);
+        SynergySetWeaponField(_weapon_struct, "projectile_behavior", combined.projectile_behavior);
+        SynergySetWeaponField(_weapon_struct, "projectile_count", combined.projectile_count);
+        SynergySetWeaponField(_weapon_struct, "projectile_spread", combined.projectile_spread);
+    }
+
+    var extra_names = struct_get_names(combined);
+    for (var n = 0; n < array_length(extra_names); n++) {
+        var name = extra_names[n];
+        if (name == "key" || name == "keys" || name == "type" || name == "damage_mult" ||
+            name == "knockback_mult" || name == "attack_speed_mult" || name == "projectile_behavior" ||
+            name == "projectile" || name == "projectile_count" || name == "projectile_spread") {
+            continue;
+        }
+
+        SynergySetWeaponField(_weapon_struct, name, combined[$ name]);
+    }
+
+    _weapon_struct.active_synergy = combined;
+    _weapon_struct.active_synergies = combined.keys;
+
+    if (instance_exists(_player) && instance_exists(_player.melee_weapon)) {
+        _player.melee_weapon.synergy_data = combined;
+    }
+}
+
+function RefreshPlayerWeaponSynergies(_player, _weapon_struct) {
+    if (!instance_exists(_player)) return;
+
+    var weapon = (_weapon_struct != undefined) ? _weapon_struct : _player.weaponCurrent;
+    if (weapon == undefined) return;
+
+    weapon = EnsureWeaponInstance(weapon);
+
+    if (_player.weaponCurrent != weapon && _weapon_struct == undefined) {
+        _player.weaponCurrent = weapon;
+    }
+
+    var extras = variable_instance_exists(_player, "active_synergy_sources") ? _player.active_synergy_sources : [];
+    var synergies = EvaluateDynamicSynergies(_player, weapon, extras);
+    ApplySynergiesToWeapon(weapon, synergies, _player);
 }


### PR DESCRIPTION
## Summary
- add a tag-driven synergy registry that captures class/weapon tags, rules, and reusable evaluation helpers
- ensure players and equipment assign synergy tags and refresh active synergies when weapons are equipped, swapped, or picked up
- clone weapon prototypes before applying synergies so each instance can track base values and reset safely

## Testing
- not run (GameMaker project)
